### PR TITLE
Issue #14 path in role.rb is wrong - change code

### DIFF
--- a/app/assets/stylesheets/cms/fortress/admin_overrides.css
+++ b/app/assets/stylesheets/cms/fortress/admin_overrides.css
@@ -5,6 +5,13 @@
   color: #3c763d;
 }
 
+.alert-error {
+  background-color: #f2dede;
+  border-color: #eed3d7;
+  color: #b94a48;
+  text-align: center;
+}
+
 .alert-notice hr {
   border-top-color: #c9e2b3;
 }
@@ -12,3 +19,5 @@
 .alert-notice .alert-link {
   color: #2b542c;
 }
+
+

--- a/app/controllers/cms/fortress/roles_controller.rb
+++ b/app/controllers/cms/fortress/roles_controller.rb
@@ -60,7 +60,12 @@ class Cms::Fortress::RolesController < Comfy::Admin::Cms::BaseController
   # POST /cms/fortress/roles.json
   def create
     @cms_fortress_role = Cms::Fortress::Role.new(role_params)
-    @cms_fortress_role.load_defaults
+    begin
+      @cms_fortress_role.load_defaults
+    rescue Error::MissingRoleConfigurationFile
+      flash[:error] = @cms_fortress_role.errors.messages[:base].first
+      render action: "new" and return
+    end
 
     respond_to do |format|
       if @cms_fortress_role.save

--- a/app/models/cms/fortress/role.rb
+++ b/app/models/cms/fortress/role.rb
@@ -10,10 +10,10 @@ class Cms::Fortress::Role < ActiveRecord::Base
     # load user custom roles
     if File.exist?(file = File.join(Rails.root, "config", "roles.yml"))
       load_from_file(file)
+    else
+      errors[:base] << I18n.t('cms.fortress.admin.errors.missing_roles_yaml_file')
+      raise Error::MissingRoleConfigurationFile
     end
-
-    file = File.expand_path(File.join(File.dirname(__FILE__), "../../../../", "config", "roles.yml"))
-    load_from_file(file)
   end
 
   private
@@ -36,3 +36,5 @@ class Cms::Fortress::Role < ActiveRecord::Base
 
   end
 end
+
+

--- a/app/models/error/missing_role_configuration_file.rb
+++ b/app/models/error/missing_role_configuration_file.rb
@@ -1,0 +1,12 @@
+module Error
+  # log error to the Rails log
+  def self.log_error(name, message)
+    Rails.logger.fatal("[ERROR:] in #{name} with message: #{message}\n\n")
+  end
+
+  class MissingRoleConfigurationFile < StandardError
+    def initialize
+      Error.log_error(self, "missing the roles.yml file in config/roles.yml")
+    end
+  end
+end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -30,6 +30,8 @@ de:
         design_related_information: Diese Seite wird Design spezifische Einstellungen zeigen.
         content_dashboard: Dashboard für Inhalte
         content_related_information: "Diese Seite wird Inhalt spezifische Einstellungen zeigen (Historie, Graphen, Analytics und andere.)"
+        errors:
+          missing_roles_yaml_file: "Die Konfigurationsdatei config/roles.yml ist nicht vorhanden."
 
       roles:
         title: Rollen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,8 @@ en:
         design_related_information: This page will show design related information.
         content_dashboard: Content Dashboard
         content_related_information: "This page will show contents related information (history, graphs, analytics and etc.)"
+        errors:
+          missing_roles_yaml_file: "The configuration file config/roles.yml is missing."
 
       roles:
         title: Roles


### PR DESCRIPTION
- removed invalid alternative pathj to roles.yml in
  app/models/cms/fortress/role.rb and added exception
  handling, if the file is not found.
- add error message css
- add Exception folder ibn models with exception
  MissingRoleCconfigurationFile
