### PR TITLE
Added the possibility to create settings

### DIFF
--- a/app/controllers/cms/fortress/roles_controller.rb
+++ b/app/controllers/cms/fortress/roles_controller.rb
@@ -60,7 +60,12 @@ class Cms::Fortress::RolesController < Comfy::Admin::Cms::BaseController
   # POST /cms/fortress/roles.json
   def create
     @cms_fortress_role = Cms::Fortress::Role.new(role_params)
-    @cms_fortress_role.load_defaults
+    begin
+      @cms_fortress_role.load_defaults
+    rescue Cms::Fortress::Error::MissingRoleConfigurationFile
+      flash[:error] = @cms_fortress_role.errors.messages[:base].first
+      render action: "new" and return
+    end
 
     respond_to do |format|
       if @cms_fortress_role.save

--- a/app/helpers/cms/fortress/application_helper.rb
+++ b/app/helpers/cms/fortress/application_helper.rb
@@ -1,3 +1,6 @@
+require 'cms/fortress/settings'
+require 'cms/fortress/error'
+
 module Cms::Fortress::ApplicationHelper
   def role_display(command)
     res = command.split(".")
@@ -84,6 +87,11 @@ module Cms::Fortress::ApplicationHelper
     Cms::Fortress.configuration.content_resources.
         map { |resource| resource[:name] }.
         include?(controller_name)
+  end
+
+  def settings
+    settings = Settings.new(:global_settings)
+    settings
   end
 end
 

--- a/app/models/cms/fortress/error.rb
+++ b/app/models/cms/fortress/error.rb
@@ -1,0 +1,18 @@
+module Cms::Fortress::Error
+  # log error to the Rails log
+  def self.log_error(name, message)
+    Rails.logger.fatal("[ERROR:] in #{name} with message: #{message}\n\n")
+  end
+
+  class MissingRoleConfigFile < StandardError
+    def initialize
+      Error.log_error(self, "missing the roles.yml file in config/roles.yml")
+    end
+  end
+
+  class MissingConfigFile < StandardError
+    def initialize
+      Error.log_error(self, "missing cms-fortress configuration file")
+    end
+  end
+end

--- a/app/models/cms/fortress/role.rb
+++ b/app/models/cms/fortress/role.rb
@@ -10,10 +10,10 @@ class Cms::Fortress::Role < ActiveRecord::Base
     # load user custom roles
     if File.exist?(file = File.join(Rails.root, "config", "roles.yml"))
       load_from_file(file)
+    else
+      errors[:base] << I18n.t('cms.fortress.admin.errors.missing_roles_yaml_file')
+      raise Cms::Fortress::Error::MissingRoleConfigurationFile
     end
-
-    file = File.expand_path(File.join(File.dirname(__FILE__), "../../../../", "config", "roles.yml"))
-    load_from_file(file)
   end
 
   private

--- a/app/models/cms/fortress/settings.rb
+++ b/app/models/cms/fortress/settings.rb
@@ -1,0 +1,17 @@
+class Settings < OpenStruct
+  def initialize(config_file_base_name)
+    @config_file_base_name = config_file_base_name
+    super(load_settings)
+  end
+
+  private
+
+  def load_settings
+    raise Cms::Fortress::Error::MissingConfigurationFile unless config_file_exists?
+    return YAML.load(ERB.new(File.read(Rails.root.join("config/cms/fortress", "#{@config_file_base_name}.yml"))).result)[Rails.env]
+  end
+
+  def config_file_exists?
+    File.exist?(File.join(Rails.root, "config/cms/fortress", "#{@config_file_base_name}.yml"))
+  end
+end

--- a/app/views/cms/fortress/shared/_menu.html.haml
+++ b/app/views/cms/fortress/shared/_menu.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-      %a.navbar-brand(href="#")= t('cms.fortress.title')
+      = link_to settings.title, settings.title_link, class: 'navbar-brand'
 
     .collapse.navbar-collapse#main-nav
       %ul.nav.navbar-nav

--- a/app/views/layouts/comfy/admin/cms/_head.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_head.html.haml
@@ -1,6 +1,6 @@
 %head
   %meta{'http-equiv' => "Content-type", :content => "text/html; charset=utf-8"}
-  %title= ComfortableMexicanSofa.config.cms_title
+  %title= settings.title
   = csrf_meta_tag
 
   = stylesheet_link_tag 'comfortable_mexican_sofa/application'

--- a/config/cms/fortress/global_settings.yml
+++ b/config/cms/fortress/global_settings.yml
@@ -1,0 +1,13 @@
+default: &default
+  title: "Kenny CMS"
+  title_link: "#"
+
+development:
+  title: "Kenny CMS"
+  title_link: "#"
+
+production:
+  <<: *default
+
+test:
+  <<: *default


### PR DESCRIPTION
I think it's a good idea to have the possibility,
to change the title and the name of the CMS via a
configuration file. Therefor I created the class Settings
and a configuration file in config/cms/fortress/global_settings.yml.

Furthermore, I moved the Error class into a Cms::Fortress namespace.
I changed the raise and rescue code to the new Error class

I would also like to insert the config/role.yml to the global_settings.yml
because then we have a proper namespace.
