### PR TITLE
reintegrated save button to trigger save without changing status

### DIFF
--- a/app/views/cms/fortress/shared/_page_extend.html.haml
+++ b/app/views/cms/fortress/shared/_page_extend.html.haml
@@ -2,4 +2,4 @@
   = form.text_field :published_date, label: t('cms.fortress.published_date'), class: "status-control", :data => {:utc_date => (@page.published_date.nil? ? Time.now : @page.published_date).strftime("%d %B, %Y") }
 
 - if Cms::Fortress.configuration.enable_page_caching
-  = form.select :cached_timeout, cached_timeout_for_select, {label: t('cms.fortress.cached_timeout'), control_col: "col-sm-4"}, {class: 'status-control'}
+  = form.select :cached_timeout, cached_timeout_for_select, {label: t('cms.fortress.cache_timeout'), control_col: "col-sm-4"}, {class: 'status-control'}

--- a/app/views/comfy/admin/cms/pages/_form.html.haml
+++ b/app/views/comfy/admin/cms/pages/_form.html.haml
@@ -36,10 +36,15 @@
 
 = render 'comfy/admin/cms/partials/page_form_after', :object => form
 
-= form.form_group :class => 'form-actions' do
-  = form.button t('.preview'), :name => 'preview', :id => nil, :class => 'btn btn-default'
+= form.form_group :class => 'form-actions', :label => { text: "Workflow" } do
   - if Cms::Fortress.configuration.enable_page_workflow
     - page_actions(@page).each do |page_action|
-      = form.button t('.'+page_action.to_s), :class => 'btn btn-primary', :value => page_action, :name => 'commit'
+      %p
+        = form.button t('.'+page_action.to_s), :class => 'btn btn-primary', :value => page_action, :name => 'transition'
+
+= form.form_group :class => 'form-actions' do
+  - if !@page.new_record?
+    = form.button t('.update'), :class => 'btn btn-success', :value => 'save', :name => 'commit'
+  = form.button t('.preview'), :name => 'preview', :id => nil, :class => 'btn btn-default'
 
 = render :partial => 'cms/fortress/shared/page_extend_js'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -16,7 +16,7 @@ de:
       cancel: Abbrechen
       published: Publiziert
       published_date: geplante Veröffentlichung
-      cached_timeout: Cache Dauer
+      cache_timeout: Cache Dauer
       toggle_navigation: Navigation einklappen
       image_selector: Bildauswahl
       insert_item: Ein Bild anklicken um es in den ausgewählten Editor einzufügen.
@@ -94,11 +94,11 @@ de:
       cms:
         pages:
           form:
-            review: Überprüfen
-            schedule: Veröffentlichung planen
-            publish: Veröffentlichen
-            draft: Entwurf speichern
-            reset: Zurücksetzen
+            review: Freigeben
+            schedule: Publizierung planen
+            publish: Jetzt publizieren
+            draft: Als Entwurf speichern
+            reset: Auf Entwurf zurücksetzen
 
   activerecord:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
       cancel: Cancel
       published: Published
       published_date: scheduled publication
-      cached_timeout: Cached Timeout
+      cache_timeout: Cached Timeout
       toggle_navigation: Toggle Navigation
       image_selector: Image Selector
       insert_item: Click the thumbnail to insert item to the selected editor.
@@ -97,11 +97,11 @@ en:
       cms:
         pages:
           form:
-            review: review
-            schedule: scheduled publish
-            publish: publish
-            draft: save draft
-            reset: reset
+            review: approve
+            schedule: schedule for publication
+            publish: publish now
+            draft: save as draft
+            reset: reset to draft
 
   activerecord:
     attributes:

--- a/lib/cms/fortress/pages_controller_methods.rb
+++ b/lib/cms/fortress/pages_controller_methods.rb
@@ -3,7 +3,7 @@ module Cms
     module PagesControllerMethods
 
       def transit_to_state
-        @page.send(params.fetch(:commit))
+        @page.send(params.fetch(:transition)) if params[:transition].present?
       end
 
       def self.included(base)

--- a/test/controllers/comfy/admin/cms/pages_controller_test.rb
+++ b/test/controllers/comfy/admin/cms/pages_controller_test.rb
@@ -22,7 +22,7 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
                 { :identifier => 'default_field_text',
                   :content    => 'title content' }
             ]
-        }, :commit => 'draft'
+        }, :transition => 'draft'
         page = Comfy::Cms::Page.last
         assert_equal @comfy_cms_site, page.site
         assert page.drafted?
@@ -46,7 +46,7 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
                 { :identifier => 'default_field_text',
                   :content    => 'title content' }
             ]
-        }, :commit => 'publish'
+        }, :transition => 'publish'
         page = Comfy::Cms::Page.last
         assert_equal @comfy_cms_site, page.site
         assert page.published?
@@ -59,7 +59,7 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
   test "drafted page should become reviewed" do
     page = comfy_cms_pages(:drafted)
     assert_no_difference 'Comfy::Cms::Block.count' do
-      put :update, :site_id => page.site, :id => page, :commit => 'review'
+      put :update, :site_id => page.site, :id => page, :transition => 'review'
       assert_response :redirect
       assert_redirected_to :action => :edit, :id => page
       assert_equal 'Page updated', flash[:success]
@@ -70,7 +70,7 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
   test "drafted page should become published" do
     page = comfy_cms_pages(:drafted)
     assert_no_difference 'Comfy::Cms::Block.count' do
-      put :update, :site_id => page.site, :id => page, :commit => 'publish'
+      put :update, :site_id => page.site, :id => page, :transition => 'publish'
       assert_response :redirect
       assert_redirected_to :action => :edit, :id => page
       assert_equal 'Page updated', flash[:success]
@@ -81,7 +81,7 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
   test "reviewed page should become published" do
     page = comfy_cms_pages(:reviewed)
     assert_no_difference 'Comfy::Cms::Block.count' do
-      put :update, :site_id => page.site, :id => page, :commit => 'publish'
+      put :update, :site_id => page.site, :id => page, :transition => 'publish'
       assert_response :redirect
       assert_redirected_to :action => :edit, :id => page
       assert_equal 'Page updated', flash[:success]
@@ -92,11 +92,24 @@ class Comfy::Admin::Cms::PagesControllerTest < ActionController::TestCase
   test "published page should become drafted" do
     page = comfy_cms_pages(:published)
     assert_no_difference 'Comfy::Cms::Block.count' do
-      put :update, :site_id => page.site, :id => page, :commit => 'reset'
+      put :update, :site_id => page.site, :id => page, :transition => 'reset'
       assert_response :redirect
       assert_redirected_to :action => :edit, :id => page
       assert_equal 'Page updated', flash[:success]
       assert assigns(:page).drafted?
     end
+  end
+
+  test "saving a page should'nt change status of a page" do
+    page = comfy_cms_pages(:drafted)
+    label = 'Arrr'
+    put :update, :site_id => page.site, :id => page, :commit => 'save', :page => {
+        :label          => label,
+    }
+    assert_response :redirect
+    assert_redirected_to :action => :edit, :id => page
+    assert_equal 'Page updated', flash[:success]
+    assert assigns(:page).drafted?
+    assert_equal assigns(:page).label, label
   end
 end


### PR DESCRIPTION
Hello Melvin,

i reintegrated the save button so that it is again possible to save a page without changing its status.
We also worked a bit on wording and usability concerning those buttons. They look much more nice and understandable now in our opinion.

Best,
Moritz
