### PR TITLE
removed executables from gemspec

### DIFF
--- a/cms-fortress.gemspec
+++ b/cms-fortress.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary           = "Comfortable Mexican Sofa (CMS) - User and role management extension"
 
   s.files             = `git ls-files`.split($/)
-  s.executables       = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.executables       = []
   s.test_files        = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths     = ["lib"]
 


### PR DESCRIPTION
this is a quick bugfix.

We integrated the executables to be able to test the gem. That have been the rake, rails and bundler binaries.  When integrating the gem into a Rails application, Rails tried to execute the executables more than one time. So we removed them form the executables list in the gemspec file. Now it is working correctly and the gem is still testable because the binaries are still inside the bin file.
