### PR TITLE
Make tinymce config generic

### DIFF
--- a/app/helpers/cms/fortress/sprocket_helper.rb
+++ b/app/helpers/cms/fortress/sprocket_helper.rb
@@ -10,22 +10,18 @@ module Cms::Fortress::SprocketHelper
     end
 
     options = {
-      menubar: 'tools format view',
-      toolbar1: 'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | table | fullscreen code',
-      toolbar2: '',
-      plugins: "['code', 'fullscreen', 'media', 'link', 'table']",
-      language: 'en'
+      menubar: "tools format view",
+      toolbar1: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | table | fullscreen code | image fmedia link",
+      toolbar2: "",
+      plugins: ["code", "fullscreen", "media", "link", "table"],
+      language: "en"
     }.stringify_keys.merge(config)
 
   <<-EOF
   tinymce.init({
+      #{configuration_from_options(options)},
       selector: 'textarea[data-cms-rich-text]',
-      menubar: '#{ options['menubar'] }',
-      toolbar1: '#{ options['toolbar1'] } | image fmedia link',
-      toolbar2: '#{ options['toolbar2'] }',
-      plugins: #{ options['plugins'] },
       link_list: CmsFortress.media.othersUrl(),
-      language: '#{ options['language'] }',
       setup: function(ed) {
         ed.addButton('image', {
           title: 'Insert Image',
@@ -46,4 +42,11 @@ module Cms::Fortress::SprocketHelper
   EOF
   end
 
+  private
+
+  def configuration_from_options(options)
+    options.map do |k, v|
+      v.is_a?(Array) ? "#{k}: #{v}" : "#{k}: '#{v}'"
+    end.join(',')
+  end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -15,7 +15,8 @@ de:
       are_you_sure: Sind Sie sicher?
       cancel: Abbrechen
       published: Publiziert
-      published_date: geplante Veröffentlichung
+      published_date: Publiziert am
+      schedule_date: geplante Publizierung
       cache_timeout: Cache Dauer
       toggle_navigation: Navigation einklappen
       image_selector: Bildauswahl


### PR DESCRIPTION
when one is adding configuration options for tinymce
into config/tinymce.yml, it was only possible to change
existing options in sprocket_helper options. I changed
the behaviour so that it's now possible to add any
options into config/tinymce.yml. Every key / value pair will
be added to tinymce.init()
