### PR TITLE
current_site was not translated

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -22,7 +22,7 @@ de:
       image_selector: Bildauswahl
       insert_item: Ein Bild anklicken um es in den ausgewählten Editor einzufügen.
       settings: Einstellungen
-      site_selector: "Seite auswählen: "
+      current_site: Aktuelle Seite
 
       admin:
         dashboard:


### PR DESCRIPTION
quick fix for missing translation in `de` for `current_site`
