### PR TITLE
extenden tinymce configuration

### DIFF
--- a/app/helpers/cms/fortress/sprocket_helper.rb
+++ b/app/helpers/cms/fortress/sprocket_helper.rb
@@ -19,12 +19,12 @@ module Cms::Fortress::SprocketHelper
 
   <<-EOF
   tinymce.init({
-      #{configuration_from_options(options)},
+      #{configuration_from_options(options)}
+      #{configuration_from_options_as_string(options)}
       selector: 'textarea[data-cms-rich-text]',
       link_list: CmsFortress.media.othersUrl(),
 
       setup: function(ed) {
-
         ed.addButton('image', {
           title: 'Insert Image',
           onclick: function() {
@@ -40,19 +40,27 @@ module Cms::Fortress::SprocketHelper
             return CmsFortress.media.showVideoDialog(ed);
           }
         });
-
       }
-
     });
   EOF
   end
 
   private
 
+  def configuration_from_options_as_string(options)
+    config = options.map do |k, v|
+      "#{k.to_s.gsub('[plain]', '')}: #{v}," if k.to_s =~ /\[plain\]/
+    end
+    config.join() if config.present?
+  end
+
   def configuration_from_options(options)
-    options.map do |k, v|
-      v.is_a?(Array) ? "#{k}: #{v}" : "#{k}: #{boolean_value(v)}"
-    end.join(',')
+    config = options.map do |k, v|
+      unless k.to_s =~ /\[plain\]/
+        v.is_a?(Array) ? "#{k}: #{v}," : "#{k}: #{boolean_value(v)},"
+      end
+    end
+    config.join()
   end
 
   def boolean_value(v)


### PR DESCRIPTION
this extends the configuration possibilities for tinymce. Because we are using a yaml file for all setting, we are kind of restricted to create JavaScript objects for the tinymce configuration. Unfortuanetly. So I added a possibility to add configuration settings like is. The key of the setting in the yaml file has the postfix [plain] like

  style_formats[plain]: |
   [
      {title: "TLN", items: [
        {title: 'Horizontale Linie', inline: 'hr'},
        {title: 'Red text', inline: 'span', styles: {color: '#ff0000'}},
        {title: 'Red header', block: 'h1', styles: {color: '#ff0000'}},
        {title: 'Example 1', inline: 'span', classes: 'example1'}
      ]}
   ]

The code above will be added to tinymce.init({ ... }) like it is.

It's not really nice but we need this! Maybe we should rethink the configuration of tinymce and move it to plain JavaScript.
