### PR TITLE
Require tinymce-rails-langs for proper langfile integration

### DIFF
--- a/lib/cms-fortress.rb
+++ b/lib/cms-fortress.rb
@@ -3,6 +3,7 @@ require 'devise'
 require 'cancan'
 require 'aasm'
 require 'tinymce-rails'
+require 'tinymce-rails-langs'
 
 require_relative 'comfortable_mexican_sofa/fixture/page'
 


### PR DESCRIPTION
The tinymce-rails-langs Engine was not activated because it had to be required.
Assets were not accessible and the tinymce-rails-langs rake task was not considered when precompiling assets.
This is solved by requiring tinymce-rails-langs.
