### PR TITLE
fix media_files_path to return path instead of url

### DIFF
--- a/app/helpers/cms/fortress/application_helper.rb
+++ b/app/helpers/cms/fortress/application_helper.rb
@@ -74,7 +74,7 @@ module Cms::Fortress::ApplicationHelper
       elsif type.eql?(:video)
         cms_fortress_files_videos_path
       else
-        cms_fortress_files_others_url(format: :json)
+        cms_fortress_files_others_path(format: :json)
       end
     end
   end


### PR DESCRIPTION
In application_helper the method media_file_path should return a path for the type others instead of url so that we have a relative path and not an url. This fixes the not working Link button in non development environments in TinyMCE Editor
