### PR TITLE
overwrite comfy admin cms files _page_form

### DIFF
--- a/app/views/comfy/admin/cms/files/_page_form.html.haml
+++ b/app/views/comfy/admin/cms/files/_page_form.html.haml
@@ -1,0 +1,17 @@
+- block ||= page_form
+
+- if (files = block.files).present?
+  .files
+    - files.each do |file|
+      .file{:class => dom_id(file)}
+        = link_to file.file.url, :target => '_blank' do
+          -geometry = Paperclip::Geometry.from_file(file.file)
+          #{file.label} | #{file.file_file_name} | #{geometry.width.to_i} x #{geometry.height.to_i} px|  #{file.file_content_type} | #{number_to_human_size(file.file_file_size, precision: 4)}
+          %br
+          %img{src: file.file.url(:cms_thumb)}
+        = link_to t('.delete'), comfy_admin_cms_site_file_path(@site, file), :method => :delete, :remote => true, :data => {:confirm => t('.are_you_sure')}, :class => 'btn btn-danger'
+
+  :coffeescript
+    $ ->
+      $("a[data-remote]").on "ajax:success", (e, data, status, xhr) ->
+        location.reload()


### PR DESCRIPTION
This is an improvement for edit pages in the cms admin, when images are uploaded. I added info of the image, a thumbnail and also the possibility to delete the image. The page is being reloaded after the image has been deleted.

Example is here: https://drive.google.com/open?id=0B2xXhdpvuHcGaGFTYU05ZGZFNFU&authuser=0

I will also created a feature request in comfy: https://github.com/comfy/comfortable-mexican-sofa/issues/577
