### PR TITLE
tinymce is default editor but there is also redactor

### DIFF
--- a/app/assets/javascripts/cms/fortress/themes/wide.js.erb
+++ b/app/assets/javascripts/cms/fortress/themes/wide.js.erb
@@ -1,11 +1,14 @@
-//= require tinymce-jquery
+<% config = Cms::Fortress::Settings.new(:global_settings).to_h %>
+
 //= require '../site_selector'
-
-
-window.CMS.wysiwyg = function () {
-  return <%= tinymce_init %>
-}
-
 $(document).ready( function() {
   $('.dropdown-toggle').dropdown();
 });
+
+<% if config[:use_tinymce] %>
+  //= require tinymce-jquery
+  window.CMS.wysiwyg = function () {
+    return <%= tinymce_init %>
+  }
+<% end %>
+

--- a/config/cms/fortress/global_settings.yml
+++ b/config/cms/fortress/global_settings.yml
@@ -1,6 +1,7 @@
 default: &default
   title: "CMS Fortress"
   title_link: "#"
+  use_tinymce: true
 
 development:
   <<: *default


### PR DESCRIPTION
since Comfy 1.12.5, there is also Redactor integrated, which comes with a image and file manager per default. So I extended the gloabl_configuration and added a flag use_tinymce with valu true. If one wants to integrate Redactor, he can simply set this to false and Redactor (if configured) will be loaded
