### PR TITLE
Make users unique per site

### DIFF
--- a/app/models/cms/fortress/user.rb
+++ b/app/models/cms/fortress/user.rb
@@ -5,8 +5,16 @@ class Cms::Fortress::User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
+  # manually add :validatable validations because uniqueness does not include :site_id
+  validates_presence_of   :email, if: :email_required?
+  validates_uniqueness_of :email, scope: :site_id, allow_blank: true, if: :email_changed?
+  validates_format_of     :email, with: Devise.email_regexp, allow_blank: true, if: :email_changed?
+  validates_presence_of     :password, if: :password_required?
+  validates_confirmation_of :password, if: :password_required?
+  validates_length_of       :password, within: Devise.password_length, allow_blank: true
   devise :database_authenticatable,
-         :recoverable, :rememberable, :trackable, :validatable, :timeoutable
+         :recoverable, :rememberable, :trackable, :timeoutable,
+         :request_keys => [:site_id]
 
   belongs_to :role
   belongs_to :site, class_name: "Comfy::Cms::Site", foreign_key: :site_id
@@ -20,6 +28,10 @@ class Cms::Fortress::User < ActiveRecord::Base
     }
   end
 
+  def self.find_for_authentication(warden_conditions)
+    where(:email => warden_conditions[:email], :site_id => warden_conditions[:site_id]).first
+  end
+
   def type
     self.class.types[type_id]
   end
@@ -27,4 +39,15 @@ class Cms::Fortress::User < ActiveRecord::Base
   def display_name
     "#{ email } (#{ type.to_s.titleize })"
   end
+
+protected
+
+  def password_required?
+    !persisted? || !password.nil? || !password_confirmation.nil?
+  end
+
+  def email_required?
+    true
+  end
+
 end

--- a/db/migrate/08_relax_user_uniqueness_on_email_and_site_id.rb
+++ b/db/migrate/08_relax_user_uniqueness_on_email_and_site_id.rb
@@ -1,0 +1,6 @@
+class RelaxUserUniquenessOnEmailAndSiteId < ActiveRecord::Migration
+  def change
+    remove_index :cms_fortress_users, :email
+    add_index :cms_fortress_users, [:email, :site_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 7) do
+ActiveRecord::Schema.define(version: 8) do
 
   create_table "cms_fortress_role_details", force: true do |t|
     t.string   "name"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 7) do
     t.integer  "site_id"
   end
 
-  add_index "cms_fortress_users", ["email"], name: "index_cms_fortress_users_on_email", unique: true
+  add_index "cms_fortress_users", ["email", "site_id"], name: "index_cms_fortress_users_on_email_and_site_id", unique: true
   add_index "cms_fortress_users", ["reset_password_token"], name: "index_cms_fortress_users_on_reset_password_token", unique: true
 
   create_table "comfy_cms_blocks", force: true do |t|


### PR DESCRIPTION
Since fortress separates users per site, the uniqueness constraint should also be relaxed per site.