### PR TITLE
Use site_id in sign_in

### DIFF
--- a/app/models/cms/fortress/user.rb
+++ b/app/models/cms/fortress/user.rb
@@ -14,7 +14,7 @@ class Cms::Fortress::User < ActiveRecord::Base
   validates_length_of       :password, within: Devise.password_length, allow_blank: true
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :timeoutable,
-         :request_keys => [:site_id]
+         :authentication_keys => [:email, :site_id]
 
   belongs_to :role
   belongs_to :site, class_name: "Comfy::Cms::Site", foreign_key: :site_id
@@ -29,7 +29,7 @@ class Cms::Fortress::User < ActiveRecord::Base
   end
 
   def self.find_for_authentication(warden_conditions)
-    where(:email => warden_conditions[:email], :site_id => warden_conditions[:site_id]).first
+    where(:email => warden_conditions[:email], :site_id => warden_conditions[:site_id]).first || where(:email => warden_conditions[:email]).first
   end
 
   def type

--- a/app/views/cms/fortress/users/sessions/new.html.haml
+++ b/app/views/cms/fortress/users/sessions/new.html.haml
@@ -10,6 +10,9 @@
         .form-group
           = f.label :password
           = f.password_field :password, :placeholder => t('cms.fortress.users.sessions.new.password'), :class => "form-control"
+        .form-group
+          = f.label :site
+          = f.select :site_id, Comfy::Cms::Site.all.collect{ |s| [s.label, s.id] }, :class => "form-control"
 
         - if devise_mapping.rememberable?
           .checkbox

--- a/lib/cms/fortress/application_controller_methods.rb
+++ b/lib/cms/fortress/application_controller_methods.rb
@@ -46,6 +46,8 @@ module Cms
       def self.included(base)
         base.class_eval do
 
+          before_action :configure_permitted_parameters, if: :devise_controller?
+
           rescue_from CanCan::AccessDenied do |ex|
             # if cannot view page check if can on files
             if controller_name.eql?('pages')
@@ -69,6 +71,12 @@ module Cms
             else
               redirect_to cms_fortress_unauthorised_path #, :alert => ex.message
             end
+          end
+
+          protected
+          
+          def configure_permitted_parameters
+            devise_parameter_sanitizer.for(:sign_in) { |u| u.permit(:email, :password, :remember_me, :site_id) }
           end
 
         end


### PR DESCRIPTION
Previous PR was incomplete, this adds the site to the login form and extends the devise configuration and lookup to find site-specific and superusers.
